### PR TITLE
Add flutter_smart_debouncer packages

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,35 @@
+name: Dart CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  core:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/flutter_smart_debouncer
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+      - run: dart pub get
+      - run: dart format --output=none --set-exit-if-changed .
+      - run: dart analyze
+      - run: dart test
+
+  widgets:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/flutter_smart_debouncer_widgets
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter format --set-exit-if-changed .
+      - run: flutter analyze
+      - run: flutter test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.dart_tool/
+.packages
+build/
+**/.DS_Store
+**/pubspec.lock

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 flutter_smart_debouncer contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# flutter_smart_debouncer
+# flutter_smart_debouncer monorepo
+
+This repository hosts the source for the `flutter_smart_debouncer` Dart package and
+its optional Flutter widget bindings.
+
+Packages:
+
+- `packages/flutter_smart_debouncer` – core, platform-agnostic debouncing and throttling utilities.
+- `packages/flutter_smart_debouncer_widgets` – Flutter widgets built on top of the core package.
+
+See the individual package directories for documentation, changelogs, and examples.

--- a/packages/flutter_smart_debouncer/CHANGELOG.md
+++ b/packages/flutter_smart_debouncer/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 0.1.0
+
+- Initial release with SmartDebouncer, DebouncePool, SmartThrottle, stream extensions, and DebouncedValue.
+- Includes documentation, tests, and examples.

--- a/packages/flutter_smart_debouncer/LICENSE
+++ b/packages/flutter_smart_debouncer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 flutter_smart_debouncer contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/flutter_smart_debouncer/README.md
+++ b/packages/flutter_smart_debouncer/README.md
@@ -1,0 +1,161 @@
+# flutter_smart_debouncer
+
+[![pub package](https://img.shields.io/pub/v/flutter_smart_debouncer.svg)](https://pub.dev/packages/flutter_smart_debouncer)
+[![Build status](https://github.com/example/flutter_smart_debouncer/actions/workflows/dart.yml/badge.svg)](https://github.com/example/flutter_smart_debouncer/actions/workflows/dart.yml)
+
+```
+  _____ _       _   _            _                 _      _                         
+ / ____| |     | | (_)          | |               | |    | |                        
+| (___ | |_ ___| |_ _  ___ ___  | |__   ___   ___ | | ___| |_ _ __ ___   ___  _ __  
+ \___ \| __/ _ \ __| |/ __/ __| | '_ \ / _ \ / _ \| |/ _ \ __| '_ ` _ \ / _ \| '_ \ 
+ ____) | ||  __/ |_| | (__\__ \ | | | | (_) | (_) | |  __/ |_| | | | | | (_) | | | |
+|_____/ \__\___|\__|_|\___|___/ |_| |_|\___/ \___/|_|\___|\__|_| |_| |_|\___/|_| |_|
+```
+
+Smart debouncing and throttling for modern Dart & Flutter apps. Keep noisy signals under control with predictable execution semantics, async safety, and polished developer experience.
+
+## Why debounce *and* throttle?
+
+Debounce waits for silence before firing, while throttle limits how often events fire. `flutter_smart_debouncer` gives you both, tuned for UI, networking, and background workloads.
+
+## Features
+
+- ✅ Async-aware debouncer with leading/trailing edges and `maxWait`
+- ✅ Per-key debounce pools for form validation and batch processing
+- ✅ Smart throttle with leading/trailing options
+- ✅ Stream extensions to debounce/throttle streams without extra deps
+- ✅ `DebouncedValue` reactive helper for state management
+- ✅ Optional Flutter bindings with `DebouncedTextField`
+- ✅ Deterministic tests with `fake_async`
+- ✅ Null-safe and web ready
+
+## Timing diagrams
+
+### Debounce (leading + trailing)
+
+```
+Calls:   |x|x|x|   |x|
+Leading: X            
+Trailing:      -----X      -----X
+```
+
+### Debounce with maxWait
+
+```
+Time -->
+Call:  x x x x x x x x
+Run:   X       X       X
+        <maxWait>
+```
+
+### Throttle (leading + trailing)
+
+```
+Calls:   |x|x|x|x|   |x|
+Leading: X       X
+Trailing:     X       X
+Interval: <----->
+```
+
+## Quick start
+
+### Simple search box debounce
+
+```dart
+final debouncer = SmartDebouncer<void>(delay: const Duration(milliseconds: 300));
+
+Future<void> onQueryChanged(String value) async {
+  await debouncer(() => search(value));
+}
+```
+
+### Auto-save with leading + trailing + maxWait
+
+```dart
+final autoSave = SmartDebouncer<void>(
+  delay: const Duration(seconds: 2),
+  leading: true,
+  trailing: true,
+  maxWait: const Duration(seconds: 8),
+);
+
+void onDocumentChanged(String snapshot) {
+  autoSave(() async {
+    await saveToServer(snapshot);
+  });
+}
+```
+
+### Per-key validation pool
+
+```dart
+final validators = DebouncePool<void>(defaultDelay: const Duration(milliseconds: 400));
+
+Future<void> validateField(String field, String value) {
+  return validators.call(field, () => validate(field, value));
+}
+```
+
+### Scroll throttle
+
+```dart
+final scrollThrottle = SmartThrottle<void>(interval: const Duration(milliseconds: 100));
+
+void onScroll() {
+  scrollThrottle(() => updateScrollPosition());
+}
+```
+
+## Stream helpers
+
+```dart
+stream.debounceTime(const Duration(milliseconds: 300));
+stream.throttleTime(
+  const Duration(milliseconds: 100),
+  leading: true,
+  trailing: true,
+);
+```
+
+## DebouncedValue
+
+```dart
+final value = DebouncedValue<int>(0, delay: const Duration(milliseconds: 200));
+value.stream.listen(print);
+value.set(1);
+value.set(2);
+```
+
+## FAQ
+
+**Why didn’t my action run?**
+
+Ensure `trailing` is true or call `flush()` to force the last action. When `leading` is true and `trailing` is false, only the first call in a burst runs.
+
+**Why did it run twice?**
+
+Using `leading` and `trailing` together means the first call fires immediately and the last call in the window fires after the delay. Disable one edge if you only need a single run.
+
+**How does `maxWait` interact with `leading`?**
+
+`maxWait` guarantees execution at most every `maxWait` duration. If `leading` is true, the first run happens immediately and `maxWait` is counted from that run.
+
+**How do I test with `fake_async`?**
+
+Wrap your test body in `fakeAsync((async) { ... })` and advance time using `async.elapse(...)`. All timers inside `SmartDebouncer` use the zone’s clock, so tests stay deterministic.
+
+**What about background tabs on the web?**
+
+Timers may be throttled by the browser; `maxWait` helps ensure periodic execution once the tab becomes active again.
+
+## Performance
+
+`SmartDebouncer` uses a single active timer per instance with O(1) updates. It avoids chained microtasks to prevent drift and works equally well on the VM and the web.
+
+## Contributing
+
+We welcome contributions! Please file an issue first, run the provided tests, and follow the included analysis options. Pull requests should include tests and updated documentation when relevant.
+
+## License
+
+[MIT](LICENSE)

--- a/packages/flutter_smart_debouncer/analysis_options.yaml
+++ b/packages/flutter_smart_debouncer/analysis_options.yaml
@@ -1,0 +1,13 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    - public_member_api_docs
+    - prefer_final_locals
+    - avoid_returning_null_for_future
+    - prefer_single_quotes
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-raw-types: true

--- a/packages/flutter_smart_debouncer/example/bin/main.dart
+++ b/packages/flutter_smart_debouncer/example/bin/main.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:flutter_smart_debouncer/flutter_smart_debouncer.dart';
+
+Future<void> main() async {
+  final debouncer = SmartDebouncer<void>(delay: const Duration(milliseconds: 300));
+  final throttle = SmartThrottle<void>(interval: const Duration(milliseconds: 200));
+  final pool = DebouncePool<void>(
+    defaultDelay: const Duration(milliseconds: 400),
+    ttl: const Duration(seconds: 5),
+  );
+
+  print('Type queries (Ctrl+C to exit):');
+  final lines = Stream.periodic(const Duration(milliseconds: 150), (i) => 'query $i').take(5);
+
+  await for (final query in lines) {
+    await debouncer(() async {
+      print('[debounce] searching for $query');
+    });
+  }
+
+  print('Simulating autosave edits');
+  for (var i = 0; i < 3; i++) {
+    debouncer(() async {
+      print('[autosave] commit revision $i');
+    });
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+  }
+
+  print('Throttle scrolling');
+  for (var i = 0; i < 5; i++) {
+    await throttle(() async {
+      print('[throttle] frame $i');
+    });
+  }
+
+  print('Per-field validation');
+  for (final field in ['email', 'username', 'email']) {
+    await pool.call(field, () async {
+      print('[pool] validating $field');
+    });
+  }
+
+  final debouncedValue = DebouncedValue<String>('', delay: const Duration(milliseconds: 200));
+  debouncedValue.stream.listen((value) => print('[value] $value'));
+  debouncedValue.set('hello');
+  debouncedValue.set('hello world');
+  await Future<void>.delayed(const Duration(milliseconds: 300));
+  await debouncedValue.close();
+}

--- a/packages/flutter_smart_debouncer/example/pubspec.yaml
+++ b/packages/flutter_smart_debouncer/example/pubspec.yaml
@@ -1,0 +1,11 @@
+name: flutter_smart_debouncer_example
+description: Example usage of flutter_smart_debouncer.
+publish_to: 'none'
+version: 1.0.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter_smart_debouncer:
+    path: ../

--- a/packages/flutter_smart_debouncer/lib/flutter_smart_debouncer.dart
+++ b/packages/flutter_smart_debouncer/lib/flutter_smart_debouncer.dart
@@ -1,0 +1,7 @@
+library flutter_smart_debouncer;
+
+export 'src/core/debounce_pool.dart';
+export 'src/core/smart_debouncer.dart';
+export 'src/core/smart_throttle.dart';
+export 'src/reactive/debounced_value.dart';
+export 'src/streams/extensions.dart';

--- a/packages/flutter_smart_debouncer/lib/src/core/debounce_pool.dart
+++ b/packages/flutter_smart_debouncer/lib/src/core/debounce_pool.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'smart_debouncer.dart';
+
+/// Maintains lazily created [SmartDebouncer] instances grouped by string keys.
+///
+/// Debouncers are reused per key and can be automatically evicted after a
+/// period of inactivity by setting [ttl].
+class DebouncePool<T> {
+  DebouncePool({
+    Duration? defaultDelay,
+    bool defaultLeading = false,
+    bool defaultTrailing = true,
+    Duration? defaultMaxWait,
+    Duration? ttl,
+  })  : _defaultDelay = defaultDelay ?? const Duration(milliseconds: 300),
+        _defaultLeading = defaultLeading,
+        _defaultTrailing = defaultTrailing,
+        _defaultMaxWait = defaultMaxWait,
+        _ttl = ttl;
+
+  final Duration _defaultDelay;
+  final bool _defaultLeading;
+  final bool _defaultTrailing;
+  final Duration? _defaultMaxWait;
+  final Duration? _ttl;
+
+  final Map<String, _PoolEntry<T>> _entries = <String, _PoolEntry<T>>{};
+
+  /// Obtains the debouncer associated with [key], creating one if necessary.
+  SmartDebouncer<T> obtain(
+    String key, {
+    Duration? delay,
+    bool? leading,
+    bool? trailing,
+    Duration? maxWait,
+  }) {
+    final requestedDelay = delay ?? _defaultDelay;
+    final requestedLeading = leading ?? _defaultLeading;
+    final requestedTrailing = trailing ?? _defaultTrailing;
+    final requestedMaxWait = maxWait ?? _defaultMaxWait;
+
+    final entry = _entries[key];
+    if (entry != null &&
+        entry.delay == requestedDelay &&
+        entry.leading == requestedLeading &&
+        entry.trailing == requestedTrailing &&
+        entry.maxWait == requestedMaxWait) {
+      entry.touch(_ttl);
+      return entry.debouncer;
+    }
+
+    entry?.dispose();
+    final debouncer = SmartDebouncer<T>(
+      delay: requestedDelay,
+      leading: requestedLeading,
+      trailing: requestedTrailing,
+      maxWait: requestedMaxWait,
+    );
+    final newEntry = _PoolEntry<T>(debouncer, requestedDelay, requestedLeading, requestedTrailing, requestedMaxWait);
+    _entries[key] = newEntry;
+    newEntry.touch(_ttl, onExpire: () => disposeKey(key));
+    return debouncer;
+  }
+
+  /// Invokes the debouncer associated with [key].
+  Future<T?> call(String key, DebounceCallback<T> action) {
+    final debouncer = obtain(key);
+    final entry = _entries[key];
+    entry?.touch(_ttl, onExpire: () => disposeKey(key));
+    return debouncer(action);
+  }
+
+  /// Cancels pending work for [key] without disposing the debouncer.
+  void cancel(String key) {
+    final entry = _entries[key];
+    entry?.debouncer.cancel();
+    entry?.touch(_ttl, onExpire: () => disposeKey(key));
+  }
+
+  /// Flushes pending work for [key], executing it immediately.
+  Future<T?> flush(String key) {
+    final entry = _entries[key];
+    if (entry == null) {
+      return Future<T?>.value(null);
+    }
+    entry.touch(_ttl, onExpire: () => disposeKey(key));
+    return entry.debouncer.flush();
+  }
+
+  /// Disposes the debouncer associated with [key].
+  void disposeKey(String key) {
+    final entry = _entries.remove(key);
+    entry?.dispose();
+  }
+
+  /// Disposes all debouncers and clears the pool.
+  void disposeAll() {
+    final keys = List<String>.of(_entries.keys);
+    for (final key in keys) {
+      disposeKey(key);
+    }
+  }
+}
+
+class _PoolEntry<T> {
+  _PoolEntry(this.debouncer, this.delay, this.leading, this.trailing, this.maxWait);
+
+  final SmartDebouncer<T> debouncer;
+  final Duration delay;
+  final bool leading;
+  final bool trailing;
+  final Duration? maxWait;
+  Timer? _ttlTimer;
+
+  void touch(Duration? ttl, {VoidCallback? onExpire}) {
+    _ttlTimer?.cancel();
+    if (ttl == null) {
+      return;
+    }
+    _ttlTimer = Timer(ttl, () {
+      onExpire?.call();
+    });
+  }
+
+  void dispose() {
+    _ttlTimer?.cancel();
+    debouncer.dispose();
+  }
+}
+
+typedef VoidCallback = void Function();

--- a/packages/flutter_smart_debouncer/lib/src/core/smart_debouncer.dart
+++ b/packages/flutter_smart_debouncer/lib/src/core/smart_debouncer.dart
@@ -1,0 +1,300 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+typedef DebounceCallback<T> = FutureOr<T> Function();
+
+@visibleForTesting
+DateTime Function() debugNow = DateTime.now;
+
+/// A smart debouncer that coalesces bursts of calls into deterministic actions.
+///
+/// The debouncer supports leading/trailing execution, optional [maxWait],
+/// pausing, flushing, and async-aware error handling.
+class SmartDebouncer<T> {
+  SmartDebouncer({
+    required Duration delay,
+    bool leading = false,
+    bool trailing = true,
+    Duration? maxWait,
+    void Function(Object error, StackTrace st)? onError,
+    void Function()? onLeadingInvoke,
+  })  : assert(!delay.isNegative, 'delay must be >= 0'),
+        assert(leading || trailing, 'Either leading or trailing must be enabled'),
+        _delay = delay,
+        _leading = leading,
+        _trailing = trailing,
+        _maxWait = maxWait,
+        _onError = onError,
+        _onLeadingInvoke = onLeadingInvoke;
+
+  final Duration _delay;
+  final bool _leading;
+  final bool _trailing;
+  final Duration? _maxWait;
+  final void Function(Object error, StackTrace st)? _onError;
+  final void Function()? _onLeadingInvoke;
+
+  final List<Completer<T?>> _waiters = <Completer<T?>>[];
+
+  Timer? _timer;
+  Timer? _maxTimer;
+  DebounceCallback<T>? _pendingAction;
+  bool _isRunning = false;
+  bool _isDisposed = false;
+  bool _isPaused = false;
+  Duration? _remainingDelay;
+  Duration? _remainingMaxWait;
+  DateTime? _delayStart;
+  DateTime? _maxStart;
+  Future<void>? _runningFuture;
+  T? _lastResult;
+
+  /// Schedules [action] according to debounce semantics.
+  Future<T?> call(DebounceCallback<T> action) {
+    _assertNotDisposed();
+
+    final completer = Completer<T?>.sync();
+    final bool shouldInvokeLeading =
+        _leading && !_isPaused && !_isRunning && _timer == null && _pendingAction == null;
+
+    if (shouldInvokeLeading) {
+      _waiters.add(completer);
+      _onLeadingInvoke?.call();
+      final future = _invoke(action);
+      _scheduleDelay();
+      _startMaxTimerIfNeeded();
+      return future;
+    }
+
+    if (_trailing) {
+      _waiters.add(completer);
+      _pendingAction = action;
+      if (!_isPaused) {
+        _scheduleDelay();
+      } else {
+        _remainingDelay = _delay;
+      }
+      _startMaxTimerIfNeeded();
+    } else {
+      if (!completer.isCompleted) {
+        completer.complete(_lastResult);
+      }
+    }
+
+    return completer.future;
+  }
+
+  /// Cancels any pending trailing invocation and completes waiting futures.
+  void cancel() {
+    if (_isDisposed) {
+      return;
+    }
+    _pendingAction = null;
+    _cancelDelayTimer();
+    _cancelMaxTimer();
+    _completeWaitersWith(null);
+  }
+
+  /// Flushes the pending trailing action, if any, executing it immediately.
+  Future<T?> flush() async {
+    _assertNotDisposed();
+
+    if (_isRunning) {
+      await _runningFuture;
+    }
+
+    final action = _pendingAction;
+    if (action == null) {
+      _cancelDelayTimer();
+      return _lastResult;
+    }
+
+    _pendingAction = null;
+    _cancelDelayTimer();
+    return _invoke(action);
+  }
+
+  /// Pauses the timers, freezing the countdown.
+  void pause() {
+    if (_isPaused || _isDisposed) {
+      return;
+    }
+    _isPaused = true;
+    if (_timer != null && _delayStart != null) {
+      final elapsed = debugNow().difference(_delayStart!);
+      _remainingDelay = _delay - elapsed;
+      if (_remainingDelay! <= Duration.zero) {
+        _remainingDelay = Duration.zero;
+      }
+    }
+    _cancelDelayTimer();
+
+    if (_maxTimer != null && _maxStart != null && _maxWait != null) {
+      final elapsed = debugNow().difference(_maxStart!);
+      final remaining = _maxWait! - elapsed;
+      _remainingMaxWait = remaining <= Duration.zero ? Duration.zero : remaining;
+    }
+    _cancelMaxTimer();
+  }
+
+  /// Resumes timers that were previously paused.
+  void resume() {
+    if (!_isPaused || _isDisposed) {
+      return;
+    }
+    _isPaused = false;
+    if (_remainingDelay != null) {
+      _scheduleDelay(overrideDelay: _remainingDelay);
+      _remainingDelay = null;
+    }
+    if (_remainingMaxWait != null) {
+      _startMaxTimerIfNeeded(overrideDelay: _remainingMaxWait);
+      _remainingMaxWait = null;
+    }
+  }
+
+  /// Whether there is a pending invocation or one currently running.
+  bool get isActive =>
+      _isRunning || _timer != null || _pendingAction != null || _maxTimer != null;
+
+  /// Whether timers are paused.
+  bool get isPaused => _isPaused;
+
+  /// Disposes the debouncer, cancelling timers and rejecting further calls.
+  void dispose() {
+    if (_isDisposed) {
+      return;
+    }
+    cancel();
+    _isDisposed = true;
+    _completeWaitersWithError(StateError('SmartDebouncer is disposed'));
+  }
+
+  void _assertNotDisposed() {
+    if (_isDisposed) {
+      throw StateError('SmartDebouncer is disposed');
+    }
+  }
+
+  Future<T?> _invoke(DebounceCallback<T> action) {
+    _pendingAction = null;
+    _cancelDelayTimer();
+
+    final localWaiters = List<Completer<T?>>.of(_waiters);
+    _waiters.clear();
+
+    _isRunning = true;
+    final execution = Future<T?>.sync(() => action());
+
+    _runningFuture = execution.then<void>((_) {}, onError: (_) {});
+    _runningFuture = _runningFuture!.whenComplete(() {
+      _isRunning = false;
+      _runningFuture = null;
+      if (_pendingAction == null) {
+        _cancelMaxTimer();
+      } else if (!_isPaused && _timer == null) {
+        _scheduleDelay();
+      }
+    });
+
+    return execution.then((value) {
+      _lastResult = value;
+      for (final waiter in localWaiters) {
+        if (!waiter.isCompleted) {
+          waiter.complete(value);
+        }
+      }
+      return value;
+    }, onError: (Object error, StackTrace stackTrace) {
+      _onError?.call(error, stackTrace);
+      for (final waiter in localWaiters) {
+        if (!waiter.isCompleted) {
+          waiter.completeError(error, stackTrace);
+        }
+      }
+      throw error;
+    });
+  }
+
+  void _scheduleDelay({Duration? overrideDelay}) {
+    _cancelDelayTimer();
+    final duration = overrideDelay ?? _delay;
+    _delayStart = debugNow();
+    _timer = Timer(duration < Duration.zero ? Duration.zero : duration, _handleDelayTimer);
+  }
+
+  void _handleDelayTimer() {
+    _timer = null;
+    if (_isPaused) {
+      return;
+    }
+    final action = _pendingAction;
+    if (!_trailing || action == null) {
+      return;
+    }
+    _pendingAction = null;
+    _invoke(action);
+  }
+
+  void _startMaxTimerIfNeeded({Duration? overrideDelay}) {
+    if (_maxWait == null) {
+      return;
+    }
+    if (_maxTimer != null) {
+      return;
+    }
+    final duration = overrideDelay ?? _maxWait!;
+    if (_isPaused) {
+      _remainingMaxWait = duration;
+      return;
+    }
+    _maxStart = debugNow();
+    _maxTimer = Timer(duration < Duration.zero ? Duration.zero : duration, _handleMaxTimer);
+  }
+
+  void _handleMaxTimer() {
+    _maxTimer = null;
+    if (_isPaused) {
+      _remainingMaxWait = Duration.zero;
+      return;
+    }
+    final action = _pendingAction;
+    if (action != null) {
+      _pendingAction = null;
+      _invoke(action);
+    }
+  }
+
+  void _cancelDelayTimer() {
+    _timer?.cancel();
+    _timer = null;
+    _delayStart = null;
+  }
+
+  void _cancelMaxTimer() {
+    _maxTimer?.cancel();
+    _maxTimer = null;
+    _maxStart = null;
+  }
+
+  void _completeWaitersWith(T? value) {
+    final localWaiters = List<Completer<T?>>.of(_waiters);
+    _waiters.clear();
+    for (final waiter in localWaiters) {
+      if (!waiter.isCompleted) {
+        waiter.complete(value);
+      }
+    }
+  }
+
+  void _completeWaitersWithError(Object error) {
+    final localWaiters = List<Completer<T?>>.of(_waiters);
+    _waiters.clear();
+    for (final waiter in localWaiters) {
+      if (!waiter.isCompleted) {
+        waiter.completeError(error);
+      }
+    }
+  }
+}

--- a/packages/flutter_smart_debouncer/lib/src/core/smart_throttle.dart
+++ b/packages/flutter_smart_debouncer/lib/src/core/smart_throttle.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+
+/// Signature for throttle callbacks.
+typedef ThrottleCallback<T> = FutureOr<T> Function();
+
+/// A throttler that limits how frequently callbacks may run.
+class SmartThrottle<T> {
+  SmartThrottle({
+    required Duration interval,
+    bool leading = true,
+    bool trailing = true,
+    void Function(Object error, StackTrace st)? onError,
+  })  : assert(!interval.isNegative, 'interval must be >= 0'),
+        assert(leading || trailing, 'Either leading or trailing must be enabled'),
+        _interval = interval,
+        _leading = leading,
+        _trailing = trailing,
+        _onError = onError;
+
+  final Duration _interval;
+  final bool _leading;
+  final bool _trailing;
+  final void Function(Object error, StackTrace st)? _onError;
+
+  final List<Completer<T?>> _waiters = <Completer<T?>>[];
+  Timer? _timer;
+  ThrottleCallback<T>? _pendingAction;
+  Future<void>? _runningFuture;
+  bool _isRunning = false;
+  bool _isDisposed = false;
+  T? _lastResult;
+
+  /// Schedules [action] according to the throttle configuration.
+  Future<T?> call(ThrottleCallback<T> action) {
+    _assertNotDisposed();
+
+    final completer = Completer<T?>.sync();
+    final bool shouldInvokeLeading = _leading && !_isRunning && _timer == null;
+
+    if (shouldInvokeLeading) {
+      _waiters.add(completer);
+      final future = _invoke(action);
+      _startTimer();
+      return future;
+    }
+
+    if (_trailing) {
+      _waiters.add(completer);
+      _pendingAction = action;
+      _startTimer();
+    } else {
+      if (!completer.isCompleted) {
+        completer.complete(_lastResult);
+      }
+    }
+
+    return completer.future;
+  }
+
+  /// Cancels pending trailing invocation without disposing the throttler.
+  void cancel() {
+    if (_isDisposed) {
+      return;
+    }
+    _pendingAction = null;
+    _timer?.cancel();
+    _timer = null;
+    _completeWaitersWith(null);
+  }
+
+  /// Executes the pending trailing invocation immediately, if any.
+  Future<T?> flush() async {
+    _assertNotDisposed();
+
+    if (_isRunning) {
+      await _runningFuture;
+    }
+
+    final action = _pendingAction;
+    if (action == null) {
+      return _lastResult;
+    }
+    _pendingAction = null;
+    _timer?.cancel();
+    _timer = null;
+    return _invoke(action);
+  }
+
+  /// Disposes the throttler and rejects further calls.
+  void dispose() {
+    if (_isDisposed) {
+      return;
+    }
+    cancel();
+    _isDisposed = true;
+    _completeWaitersWithError(StateError('SmartThrottle is disposed'));
+  }
+
+  void _startTimer() {
+    _timer ??= Timer(_interval, _handleTimer);
+  }
+
+  void _handleTimer() {
+    _timer = null;
+    final action = _pendingAction;
+    if (!_trailing || action == null) {
+      return;
+    }
+    _pendingAction = null;
+    _invoke(action);
+  }
+
+  Future<T?> _invoke(ThrottleCallback<T> action) {
+    final localWaiters = List<Completer<T?>>.of(_waiters);
+    _waiters.clear();
+
+    _isRunning = true;
+    final execution = Future<T?>.sync(() => action());
+    _runningFuture = execution.then<void>((_) {}, onError: (_) {});
+    _runningFuture = _runningFuture!.whenComplete(() {
+      _isRunning = false;
+      _runningFuture = null;
+      if (_timer == null && _pendingAction != null) {
+        _startTimer();
+      }
+    });
+
+    return execution.then((value) {
+      _lastResult = value;
+      for (final waiter in localWaiters) {
+        if (!waiter.isCompleted) {
+          waiter.complete(value);
+        }
+      }
+      return value;
+    }, onError: (Object error, StackTrace stackTrace) {
+      _onError?.call(error, stackTrace);
+      for (final waiter in localWaiters) {
+        if (!waiter.isCompleted) {
+          waiter.completeError(error, stackTrace);
+        }
+      }
+      throw error;
+    });
+  }
+
+  void _completeWaitersWith(T? value) {
+    final localWaiters = List<Completer<T?>>.of(_waiters);
+    _waiters.clear();
+    for (final waiter in localWaiters) {
+      if (!waiter.isCompleted) {
+        waiter.complete(value);
+      }
+    }
+  }
+
+  void _completeWaitersWithError(Object error) {
+    final localWaiters = List<Completer<T?>>.of(_waiters);
+    _waiters.clear();
+    for (final waiter in localWaiters) {
+      if (!waiter.isCompleted) {
+        waiter.completeError(error);
+      }
+    }
+  }
+
+  void _assertNotDisposed() {
+    if (_isDisposed) {
+      throw StateError('SmartThrottle is disposed');
+    }
+  }
+}

--- a/packages/flutter_smart_debouncer/lib/src/reactive/debounced_value.dart
+++ b/packages/flutter_smart_debouncer/lib/src/reactive/debounced_value.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import '../core/smart_debouncer.dart';
+
+/// Stores a value and emits updates after a debounce delay.
+class DebouncedValue<T> {
+  DebouncedValue(T initial, {required Duration delay})
+      : _value = initial,
+        _controller = StreamController<T>.broadcast(sync: true),
+        _debouncer = SmartDebouncer<void>(delay: delay);
+
+  final SmartDebouncer<void> _debouncer;
+  final StreamController<T> _controller;
+  T _value;
+  bool _isClosed = false;
+
+  /// The current value.
+  T get value => _value;
+
+  /// A broadcast stream that emits debounced updates.
+  Stream<T> get stream => _controller.stream;
+
+  /// Sets the next value and schedules a debounced emission.
+  void set(T next) {
+    if (_isClosed) {
+      throw StateError('DebouncedValue is closed');
+    }
+    _value = next;
+    _debouncer(() {
+      if (!_controller.isClosed) {
+        _controller.add(_value);
+      }
+    });
+  }
+
+  /// Closes the debouncer and the underlying stream controller.
+  Future<void> close() async {
+    if (_isClosed) {
+      return;
+    }
+    _isClosed = true;
+    _debouncer.dispose();
+    await _controller.close();
+  }
+}

--- a/packages/flutter_smart_debouncer/lib/src/streams/extensions.dart
+++ b/packages/flutter_smart_debouncer/lib/src/streams/extensions.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+extension SmartDebounceStream<T> on Stream<T> {
+  /// Emits events from this stream only after the source has been silent for
+  /// [duration].
+  Stream<T> debounceTime(Duration duration) {
+    assert(!duration.isNegative, 'duration must be >= 0');
+    final source = this;
+    return Stream<T>.multi((controller) {
+      Timer? timer;
+      T? latest;
+      var hasLatest = false;
+      late StreamSubscription<T> subscription;
+
+      void emit() {
+        if (hasLatest) {
+          controller.add(latest as T);
+          hasLatest = false;
+          latest = null;
+        }
+      }
+
+      controller.onListen = () {
+        subscription = source.listen((event) {
+          timer?.cancel();
+          latest = event;
+          hasLatest = true;
+          timer = Timer(duration, emit);
+        }, onError: controller.addError, onDone: () {
+          timer?.cancel();
+          emit();
+          controller.close();
+        }, cancelOnError: false);
+      };
+
+      controller.onPause = () {
+        subscription.pause();
+      };
+
+      controller.onResume = () {
+        subscription.resume();
+      };
+
+      controller.onCancel = () async {
+        timer?.cancel();
+        await subscription.cancel();
+      };
+    }, isBroadcast: false);
+  }
+
+  /// Emits at most one value per [duration], honoring the [leading] and
+  /// [trailing] edge configuration.
+  Stream<T> throttleTime(Duration duration, {bool leading = true, bool trailing = true}) {
+    assert(!duration.isNegative, 'duration must be >= 0');
+    assert(leading || trailing, 'Either leading or trailing must be enabled');
+    final source = this;
+    return Stream<T>.multi((controller) {
+      Timer? timer;
+      T? trailingValue;
+      var hasTrailingValue = false;
+      var windowOpen = false;
+      late StreamSubscription<T> subscription;
+
+      void openWindow() {
+        windowOpen = true;
+        timer = Timer(duration, () {
+          timer = null;
+          windowOpen = false;
+          if (trailing && hasTrailingValue) {
+            controller.add(trailingValue as T);
+            hasTrailingValue = false;
+            trailingValue = null;
+            openWindow();
+          }
+        });
+      }
+
+      controller.onListen = () {
+        subscription = source.listen((event) {
+          if (!windowOpen) {
+            openWindow();
+            if (leading) {
+              controller.add(event);
+            } else if (trailing) {
+              trailingValue = event;
+              hasTrailingValue = true;
+            }
+            return;
+          }
+
+          if (trailing) {
+            trailingValue = event;
+            hasTrailingValue = true;
+          }
+        }, onError: controller.addError, onDone: () {
+          timer?.cancel();
+          if (trailing && hasTrailingValue) {
+            controller.add(trailingValue as T);
+          }
+          controller.close();
+        }, cancelOnError: false);
+      };
+
+      controller.onPause = () {
+        subscription.pause();
+      };
+
+      controller.onResume = () {
+        subscription.resume();
+      };
+
+      controller.onCancel = () async {
+        timer?.cancel();
+        await subscription.cancel();
+      };
+    }, isBroadcast: false);
+  }
+}

--- a/packages/flutter_smart_debouncer/pubspec.yaml
+++ b/packages/flutter_smart_debouncer/pubspec.yaml
@@ -1,0 +1,17 @@
+name: flutter_smart_debouncer
+version: 0.1.0
+
+description: Smart debouncing and throttling utilities for Dart and Flutter with async support, pooling, and stream helpers.
+repository: https://github.com/example/flutter_smart_debouncer
+issue_tracker: https://github.com/example/flutter_smart_debouncer/issues
+homepage: https://github.com/example/flutter_smart_debouncer
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  meta: ^1.10.0
+
+dev_dependencies:
+  test: ^1.24.0
+  lints: ^3.0.0

--- a/packages/flutter_smart_debouncer/test/debounce_pool_test.dart
+++ b/packages/flutter_smart_debouncer/test/debounce_pool_test.dart
@@ -1,0 +1,69 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_smart_debouncer/flutter_smart_debouncer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  tearDown(() {
+    debugNow = DateTime.now;
+  });
+
+  test('per-key isolation', () async {
+    Future<int?>? aFuture;
+    Future<int?>? bFuture;
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final pool = DebouncePool<int>(defaultDelay: const Duration(milliseconds: 100));
+
+      var aCount = 0;
+      var bCount = 0;
+      aFuture = pool.call('a', () => ++aCount);
+      bFuture = pool.call('b', () => ++bCount);
+
+      async.elapse(const Duration(milliseconds: 120));
+      expect(aCount, 1);
+      expect(bCount, 1);
+    });
+
+    expect(await aFuture!, 1);
+    expect(await bFuture!, 1);
+  });
+
+  test('ttl eviction disposes idle debouncers', () {
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final pool = DebouncePool<void>(
+        defaultDelay: const Duration(milliseconds: 10),
+        ttl: const Duration(milliseconds: 50),
+      );
+
+      final first = pool.obtain('key');
+      async.elapse(const Duration(milliseconds: 60));
+      final second = pool.obtain('key');
+      expect(identical(first, second), isFalse);
+    });
+  });
+
+  test('cancel and flush operate per key', () async {
+    Future<int?>? future;
+    Future<int?>? flushed;
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final pool = DebouncePool<int>(defaultDelay: const Duration(milliseconds: 100));
+
+      var value = 0;
+      future = pool.call('foo', () => ++value);
+      pool.cancel('foo');
+      async.elapse(const Duration(milliseconds: 150));
+      expect(value, 0);
+
+      future = pool.call('foo', () => ++value);
+      async.elapse(const Duration(milliseconds: 10));
+      flushed = pool.flush('foo');
+      async.elapse(const Duration(milliseconds: 1));
+      expect(value, 1);
+    });
+
+    expect(await future!, 1);
+    expect(await flushed!, 1);
+  });
+}

--- a/packages/flutter_smart_debouncer/test/debounced_value_test.dart
+++ b/packages/flutter_smart_debouncer/test/debounced_value_test.dart
@@ -1,0 +1,32 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_smart_debouncer/flutter_smart_debouncer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  tearDown(() {
+    debugNow = DateTime.now;
+  });
+
+  test('DebouncedValue emits via stream after delay', () {
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final value = DebouncedValue<int>(0, delay: const Duration(milliseconds: 50));
+      final outputs = <int>[];
+      value.stream.listen(outputs.add);
+
+      value.set(1);
+      async.elapse(const Duration(milliseconds: 30));
+      value.set(2);
+      async.elapse(const Duration(milliseconds: 30));
+
+      expect(outputs, [2]);
+      value.close();
+    });
+  });
+
+  test('DebouncedValue throws after close', () async {
+    final value = DebouncedValue<int>(0, delay: const Duration(milliseconds: 10));
+    await value.close();
+    expect(() => value.set(1), throwsStateError);
+  });
+}

--- a/packages/flutter_smart_debouncer/test/smart_debouncer_test.dart
+++ b/packages/flutter_smart_debouncer/test/smart_debouncer_test.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_smart_debouncer/flutter_smart_debouncer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  tearDown(() {
+    debugNow = DateTime.now;
+  });
+
+  test('leading only executes immediately and ignores trailing calls', () async {
+    final futures = <Future<int?>>[];
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final debouncer = SmartDebouncer<int>(
+        delay: const Duration(milliseconds: 100),
+        leading: true,
+        trailing: false,
+      );
+
+      var count = 0;
+      final first = debouncer(() => ++count);
+      futures.add(first);
+      expect(count, 1);
+
+      async.elapse(const Duration(milliseconds: 50));
+      final second = debouncer(() => ++count);
+      futures.add(second);
+      expect(count, 1);
+
+      async.elapse(const Duration(milliseconds: 60));
+      final third = debouncer(() => ++count);
+      futures.add(third);
+      expect(count, 2);
+    });
+
+    final values = await Future.wait(futures);
+    expect(values.first, 1);
+    expect(values[1], 1);
+    expect(values.last, 2);
+  });
+
+  test('trailing only executes once after delay', () async {
+    final futures = <Future<int?>>[];
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final debouncer = SmartDebouncer<int>(
+        delay: const Duration(milliseconds: 100),
+      );
+
+      var count = 0;
+      futures.add(debouncer(() => ++count));
+      futures.add(debouncer(() => ++count));
+      expect(count, 0);
+
+      async.elapse(const Duration(milliseconds: 100));
+      expect(count, 1);
+    });
+
+    final values = await Future.wait(futures);
+    expect(values, everyElement(1));
+  });
+
+  test('leading and trailing executes on both edges', () async {
+    final futures = <Future<int?>>[];
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final debouncer = SmartDebouncer<int>(
+        delay: const Duration(milliseconds: 100),
+        leading: true,
+        trailing: true,
+      );
+
+      var value = 0;
+      futures.add(debouncer(() => ++value));
+      expect(value, 1);
+
+      async.elapse(const Duration(milliseconds: 50));
+      futures.add(debouncer(() => ++value));
+      async.elapse(const Duration(milliseconds: 50));
+      expect(value, 1);
+
+      async.elapse(const Duration(milliseconds: 50));
+      expect(value, 2);
+    });
+
+    final values = await Future.wait(futures);
+    expect(values.first, 1);
+    expect(values.last, 2);
+  });
+
+  test('maxWait enforces execution cadence during rapid calls', () async {
+    final futures = <Future<int?>>[];
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final debouncer = SmartDebouncer<int>(
+        delay: const Duration(milliseconds: 100),
+        leading: false,
+        trailing: true,
+        maxWait: const Duration(milliseconds: 250),
+      );
+
+      var calls = 0;
+      Future<int?> tick() => debouncer(() => ++calls);
+
+      for (var i = 0; i < 5; i++) {
+        futures.add(tick());
+        async.elapse(const Duration(milliseconds: 60));
+      }
+
+      expect(calls, 0);
+      async.elapse(const Duration(milliseconds: 80));
+      expect(calls, greaterThanOrEqualTo(1));
+    });
+
+    final results = await Future.wait(futures);
+    expect(results.whereType<int?>().length, equals(results.length));
+  });
+
+  test('pause and resume preserves remaining delay', () async {
+    Future<int?>? future;
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final debouncer = SmartDebouncer<int>(delay: const Duration(milliseconds: 100));
+
+      var result = 0;
+      future = debouncer(() => ++result);
+      async.elapse(const Duration(milliseconds: 40));
+      debouncer.pause();
+      async.elapse(const Duration(milliseconds: 200));
+      expect(result, 0);
+      debouncer.resume();
+      async.elapse(const Duration(milliseconds: 61));
+      expect(result, 1);
+    });
+
+    final value = await future!;
+    expect(value, 1);
+  });
+
+  test('onLeadingInvoke triggers on immediate execution', () async {
+    var leadingCount = 0;
+    Future<int?>? future;
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final debouncer = SmartDebouncer<int>(
+        delay: const Duration(milliseconds: 100),
+        leading: true,
+        trailing: false,
+        onLeadingInvoke: () => leadingCount++,
+      );
+
+      future = debouncer(() => 42);
+      async.elapse(const Duration(milliseconds: 10));
+    });
+
+    expect(await future!, 42);
+    expect(leadingCount, 1);
+  });
+
+  test('cancel prevents trailing execution', () async {
+    Future<int?>? future;
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final debouncer = SmartDebouncer<int>(delay: const Duration(milliseconds: 50));
+
+      var value = 0;
+      future = debouncer(() => ++value);
+      debouncer.cancel();
+      async.elapse(const Duration(milliseconds: 50));
+      expect(value, 0);
+    });
+
+    final result = await future!;
+    expect(result, isNull);
+  });
+
+  test('flush executes immediately when idle', () async {
+    Future<int?>? future;
+    Future<int?>? flushFuture;
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final debouncer = SmartDebouncer<int>(delay: const Duration(milliseconds: 100));
+
+      var count = 0;
+      future = debouncer(() => ++count);
+      async.elapse(const Duration(milliseconds: 20));
+      flushFuture = debouncer.flush();
+      expect(count, 1);
+    });
+
+    expect(await future!, 1);
+    expect(await flushFuture!, 1);
+  });
+
+  test('flush waits for running action then executes pending one', () async {
+    Future<void>? flushFuture;
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final debouncer = SmartDebouncer<void>(delay: const Duration(milliseconds: 100));
+
+      final log = <String>[];
+      final completer = Completer<void>();
+      debouncer(() async {
+        log.add('start');
+        await completer.future;
+        log.add('end');
+      });
+
+      async.elapse(const Duration(milliseconds: 10));
+      flushFuture = debouncer.flush();
+      log.add('flush called');
+      debouncer(() {
+        log.add('pending');
+      });
+      async.elapse(const Duration(milliseconds: 20));
+      completer.complete();
+      async.elapse(const Duration(milliseconds: 100));
+
+      expect(log, ['start', 'flush called', 'end', 'pending']);
+    });
+
+    await flushFuture;
+  });
+
+  test('propagates async errors and calls onError', () async {
+    Future<void>? future;
+    Object? captured;
+    StackTrace? capturedTrace;
+    fakeAsync((async) {
+      debugNow = () => async.getClock(DateTime.now).now();
+      final debouncer = SmartDebouncer<void>(
+        delay: const Duration(milliseconds: 10),
+        onError: (error, stackTrace) {
+          captured = error;
+          capturedTrace = stackTrace;
+        },
+      );
+
+      future = debouncer(() async {
+        await Future<void>.value();
+        throw StateError('boom');
+      });
+      async.elapse(const Duration(milliseconds: 20));
+    });
+
+    await expectLater(future, throwsA(isA<StateError>()));
+    expect(captured, isA<StateError>());
+    expect(capturedTrace, isNotNull);
+  });
+}

--- a/packages/flutter_smart_debouncer/test/smart_throttle_test.dart
+++ b/packages/flutter_smart_debouncer/test/smart_throttle_test.dart
@@ -1,0 +1,97 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_smart_debouncer/flutter_smart_debouncer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('leading true trailing false throttles to first call', () async {
+    final futures = <Future<int?>>[];
+    fakeAsync((async) {
+      final throttle = SmartThrottle<int>(
+        interval: const Duration(milliseconds: 100),
+        leading: true,
+        trailing: false,
+      );
+
+      var count = 0;
+      futures.add(throttle(() => ++count));
+      async.elapse(const Duration(milliseconds: 10));
+      futures.add(throttle(() => ++count));
+      async.elapse(const Duration(milliseconds: 200));
+      futures.add(throttle(() => ++count));
+    });
+
+    final results = await Future.wait(futures);
+    expect(results, [1, 1, 2]);
+  });
+
+  test('leading false trailing true throttles to last call', () async {
+    final futures = <Future<int?>>[];
+    fakeAsync((async) {
+      final throttle = SmartThrottle<int>(
+        interval: const Duration(milliseconds: 100),
+        leading: false,
+        trailing: true,
+      );
+
+      var count = 0;
+      futures.add(throttle(() => ++count));
+      async.elapse(const Duration(milliseconds: 40));
+      futures.add(throttle(() => ++count));
+      async.elapse(const Duration(milliseconds: 120));
+    });
+
+    final results = await Future.wait(futures);
+    expect(results.first, 2);
+    expect(results.last, 2);
+  });
+
+  test('leading and trailing emit both edges when busy', () async {
+    final futures = <Future<int?>>[];
+    fakeAsync((async) {
+      final throttle = SmartThrottle<int>(
+        interval: const Duration(milliseconds: 100),
+      );
+
+      var value = 0;
+      futures.add(throttle(() => ++value));
+      async.elapse(const Duration(milliseconds: 20));
+      futures.add(throttle(() => ++value));
+      async.elapse(const Duration(milliseconds: 120));
+      futures.add(throttle(() => ++value));
+      async.elapse(const Duration(milliseconds: 120));
+    });
+
+    final results = await Future.wait(futures);
+    expect(results.first, 1);
+    expect(results[1], anyOf(1, 2));
+    expect(results.last, 3);
+  });
+
+  test('cancel prevents trailing execution', () async {
+    Future<int?>? future;
+    fakeAsync((async) {
+      final throttle = SmartThrottle<int>(interval: const Duration(milliseconds: 100));
+      var count = 0;
+      future = throttle(() => ++count);
+      throttle.cancel();
+      async.elapse(const Duration(milliseconds: 200));
+      expect(count, 1);
+    });
+
+    expect(await future!, 1);
+  });
+
+  test('flush executes pending trailing action', () async {
+    Future<int?>? future;
+    fakeAsync((async) {
+      final throttle = SmartThrottle<int>(interval: const Duration(milliseconds: 100));
+      var value = 0;
+      throttle(() => ++value);
+      async.elapse(const Duration(milliseconds: 10));
+      future = throttle.flush();
+      expect(value, 1);
+    });
+
+    expect(await future!, 1);
+  });
+}

--- a/packages/flutter_smart_debouncer/test/stream_extensions_test.dart
+++ b/packages/flutter_smart_debouncer/test/stream_extensions_test.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_smart_debouncer/flutter_smart_debouncer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('debounceTime emits last value after quiet period', () {
+    fakeAsync((async) {
+      final controller = StreamController<int>();
+      final events = <int>[];
+      controller.stream.debounceTime(const Duration(milliseconds: 50)).listen(events.add);
+
+      controller.add(1);
+      async.elapse(const Duration(milliseconds: 40));
+      controller.add(2);
+      async.elapse(const Duration(milliseconds: 60));
+      expect(events, [2]);
+
+      controller.close();
+    });
+  });
+
+  test('throttleTime with leading emits first and trailing emits last', () {
+    fakeAsync((async) {
+      final controller = StreamController<int>();
+      final events = <int>[];
+      controller
+          .stream
+          .throttleTime(const Duration(milliseconds: 100), leading: true, trailing: true)
+          .listen(events.add);
+
+      controller.add(1);
+      async.elapse(const Duration(milliseconds: 20));
+      controller.add(2);
+      async.elapse(const Duration(milliseconds: 120));
+      controller.add(3);
+      async.elapse(const Duration(milliseconds: 120));
+
+      expect(events, [1, 2, 3]);
+      controller.close();
+    });
+  });
+
+  test('cancelling listener stops timers', () {
+    fakeAsync((async) {
+      final controller = StreamController<int>();
+      final subscription = controller.stream.debounceTime(const Duration(milliseconds: 100)).listen((_) {});
+      controller.add(1);
+      async.elapse(const Duration(milliseconds: 10));
+      subscription.cancel();
+      async.elapse(const Duration(milliseconds: 200));
+      expect(() {}, returnsNormally);
+      controller.close();
+    });
+  });
+}

--- a/packages/flutter_smart_debouncer_widgets/CHANGELOG.md
+++ b/packages/flutter_smart_debouncer_widgets/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+- Initial release with DebouncedTextField widget example and tests.

--- a/packages/flutter_smart_debouncer_widgets/LICENSE
+++ b/packages/flutter_smart_debouncer_widgets/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 flutter_smart_debouncer contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/flutter_smart_debouncer_widgets/README.md
+++ b/packages/flutter_smart_debouncer_widgets/README.md
@@ -1,0 +1,22 @@
+# flutter_smart_debouncer_widgets
+
+Flutter bindings for [`flutter_smart_debouncer`](../flutter_smart_debouncer). This package provides
+a drop-in `DebouncedTextField` widget for text entry scenarios where you want to delay expensive
+work until the user pauses typing.
+
+## DebouncedTextField
+
+```dart
+DebouncedTextField(
+  delay: const Duration(milliseconds: 400),
+  decoration: const InputDecoration(labelText: 'Search'),
+  onChangedDebounced: (value) => fetchResults(value),
+)
+```
+
+- Emits the latest value after the specified [delay].
+- Supports leading invocations via `leading: true` to fire immediately and still emit trailing values.
+- Bubbles the underlying `TextField` callbacks and configuration.
+
+See the example app for an end-to-end demonstration featuring a search bar, auto-save indicator, and
+scroll position throttle.

--- a/packages/flutter_smart_debouncer_widgets/analysis_options.yaml
+++ b/packages/flutter_smart_debouncer_widgets/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    - public_member_api_docs

--- a/packages/flutter_smart_debouncer_widgets/example/lib/main.dart
+++ b/packages/flutter_smart_debouncer_widgets/example/lib/main.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_smart_debouncer/flutter_smart_debouncer.dart';
+import 'package:flutter_smart_debouncer_widgets/debounced_text_field.dart';
+
+void main() {
+  runApp(const DebouncerDemoApp());
+}
+
+class DebouncerDemoApp extends StatelessWidget {
+  const DebouncerDemoApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Smart Debouncer Demo',
+      theme: ThemeData(colorSchemeSeed: Colors.blue, useMaterial3: true),
+      home: const DemoPage(),
+    );
+  }
+}
+
+class DemoPage extends StatefulWidget {
+  const DemoPage({super.key});
+
+  @override
+  State<DemoPage> createState() => _DemoPageState();
+}
+
+class _DemoPageState extends State<DemoPage> {
+  final SmartDebouncer<void> _autoSave = SmartDebouncer<void>(
+    delay: const Duration(seconds: 2),
+    leading: true,
+    trailing: true,
+    maxWait: const Duration(seconds: 6),
+  );
+  final SmartThrottle<void> _scrollThrottle = SmartThrottle<void>(
+    interval: const Duration(milliseconds: 250),
+  );
+  final DebouncePool<void> _validationPool = DebouncePool<void>(
+    defaultDelay: const Duration(milliseconds: 600),
+  );
+  final ScrollController _scrollController = ScrollController();
+
+  String _searchStatus = 'Idle';
+  String _autosaveStatus = 'Synced';
+  String _scrollStatus = 'Stopped';
+  String _emailStatus = 'Idle';
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(() {
+      _scrollThrottle(() async {
+        setState(() {
+          _scrollStatus = 'Scroll position ${_scrollController.offset.toStringAsFixed(1)}';
+        });
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _autoSave.dispose();
+    _scrollThrottle.dispose();
+    _validationPool.disposeAll();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _runSearch(String query) async {
+    setState(() {
+      _searchStatus = 'Searching "$query"…';
+    });
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+    if (!mounted) return;
+    setState(() {
+      _searchStatus = 'Results ready for "$query"';
+    });
+  }
+
+  void _onDocumentEdited(String value) {
+    setState(() {
+      _autosaveStatus = 'Dirty';
+    });
+    _autoSave(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      if (!mounted) return;
+      setState(() {
+        _autosaveStatus = 'Saved at ${TimeOfDay.now().format(context)}';
+      });
+    });
+  }
+
+  void _validateEmail(String value) {
+    _validationPool.call('email', () async {
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      if (!mounted) return;
+      setState(() {
+        _emailStatus = value.contains('@') ? 'Looks good!' : 'Missing @ symbol';
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Smart Debouncer Demo')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Search', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            DebouncedTextField(
+              delay: const Duration(milliseconds: 350),
+              leading: false,
+              onChangedDebounced: _runSearch,
+              decoration: const InputDecoration(prefixIcon: Icon(Icons.search), hintText: 'Search…'),
+            ),
+            const SizedBox(height: 4),
+            Text(_searchStatus),
+            const Divider(height: 32),
+            Text('Auto-save', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            TextField(
+              maxLines: 3,
+              decoration: const InputDecoration(border: OutlineInputBorder(), hintText: 'Type to auto-save…'),
+              onChanged: _onDocumentEdited,
+            ),
+            const SizedBox(height: 4),
+            Text(_autosaveStatus),
+            const Divider(height: 32),
+            Text('Form validation (per-key)', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            TextField(
+              decoration: const InputDecoration(labelText: 'Email'),
+              keyboardType: TextInputType.emailAddress,
+              onChanged: _validateEmail,
+            ),
+            const SizedBox(height: 4),
+            Text(_emailStatus),
+            const Divider(height: 32),
+            Text('Scroll throttle', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Expanded(
+              child: ListView.builder(
+                controller: _scrollController,
+                itemCount: 100,
+                itemBuilder: (context, index) => ListTile(title: Text('Item $index')),
+              ),
+            ),
+            Text(_scrollStatus),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flutter_smart_debouncer_widgets/example/pubspec.yaml
+++ b/packages/flutter_smart_debouncer_widgets/example/pubspec.yaml
@@ -1,0 +1,22 @@
+name: flutter_smart_debouncer_widgets_example
+description: Example Flutter app for flutter_smart_debouncer_widgets.
+publish_to: 'none'
+version: 1.0.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.10.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_smart_debouncer_widgets:
+    path: ../
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true

--- a/packages/flutter_smart_debouncer_widgets/lib/debounced_text_field.dart
+++ b/packages/flutter_smart_debouncer_widgets/lib/debounced_text_field.dart
@@ -1,0 +1,158 @@
+library flutter_smart_debouncer_widgets;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_smart_debouncer/flutter_smart_debouncer.dart';
+
+/// A [TextField] that debounces the [onChangedDebounced] callback.
+class DebouncedTextField extends StatefulWidget {
+  const DebouncedTextField({
+    super.key,
+    required this.delay,
+    this.leading = false,
+    this.trailing = true,
+    this.maxWait,
+    this.onChangedDebounced,
+    this.onChanged,
+    this.controller,
+    this.focusNode,
+    this.decoration,
+    this.keyboardType,
+    this.textInputAction,
+    this.style,
+    this.textAlign = TextAlign.start,
+    this.autofocus = false,
+    this.obscureText = false,
+    this.enabled,
+    this.minLines,
+    this.maxLines = 1,
+    this.onSubmitted,
+  })  : assert(!delay.isNegative, 'delay must be >= 0'),
+        assert(leading || trailing, 'Either leading or trailing must be enabled');
+
+  /// Debounce duration before firing [onChangedDebounced].
+  final Duration delay;
+
+  /// Whether to invoke the debounced callback immediately on the leading edge.
+  final bool leading;
+
+  /// Whether to invoke the debounced callback on the trailing edge.
+  final bool trailing;
+
+  /// Ensures a callback at least every [maxWait] duration if provided.
+  final Duration? maxWait;
+
+  /// Debounced change callback.
+  final ValueChanged<String>? onChangedDebounced;
+
+  /// Immediate change callback forwarded to the underlying [TextField].
+  final ValueChanged<String>? onChanged;
+
+  /// Controller for the underlying [TextField].
+  final TextEditingController? controller;
+
+  /// Focus node for the underlying [TextField].
+  final FocusNode? focusNode;
+
+  /// Decoration for the text field.
+  final InputDecoration? decoration;
+
+  /// Keyboard type for the field.
+  final TextInputType? keyboardType;
+
+  /// Text input action.
+  final TextInputAction? textInputAction;
+
+  /// Style for the entered text.
+  final TextStyle? style;
+
+  /// Alignment for the text.
+  final TextAlign textAlign;
+
+  /// Whether the field autofocuses.
+  final bool autofocus;
+
+  /// Whether the field obscures text.
+  final bool obscureText;
+
+  /// Whether the field is enabled.
+  final bool? enabled;
+
+  /// Minimum lines for the field.
+  final int? minLines;
+
+  /// Maximum lines for the field.
+  final int? maxLines;
+
+  /// Callback when the user submits the field.
+  final ValueChanged<String>? onSubmitted;
+
+  @override
+  State<DebouncedTextField> createState() => _DebouncedTextFieldState();
+}
+
+class _DebouncedTextFieldState extends State<DebouncedTextField> {
+  late SmartDebouncer<void> _debouncer;
+
+  @override
+  void initState() {
+    super.initState();
+    _debouncer = _createDebouncer();
+  }
+
+  @override
+  void didUpdateWidget(DebouncedTextField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.delay != widget.delay ||
+        oldWidget.leading != widget.leading ||
+        oldWidget.trailing != widget.trailing ||
+        oldWidget.maxWait != widget.maxWait) {
+      _debouncer.dispose();
+      _debouncer = _createDebouncer();
+    }
+  }
+
+  @override
+  void dispose() {
+    _debouncer.dispose();
+    super.dispose();
+  }
+
+  SmartDebouncer<void> _createDebouncer() {
+    return SmartDebouncer<void>(
+      delay: widget.delay,
+      leading: widget.leading,
+      trailing: widget.trailing,
+      maxWait: widget.maxWait,
+    );
+  }
+
+  void _handleChanged(String value) {
+    widget.onChanged?.call(value);
+    final debounced = widget.onChangedDebounced;
+    if (debounced != null) {
+      _debouncer(() async {
+        debounced(value);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: widget.controller,
+      focusNode: widget.focusNode,
+      decoration: widget.decoration,
+      keyboardType: widget.keyboardType,
+      textInputAction: widget.textInputAction,
+      style: widget.style,
+      textAlign: widget.textAlign,
+      autofocus: widget.autofocus,
+      obscureText: widget.obscureText,
+      enabled: widget.enabled,
+      minLines: widget.minLines,
+      maxLines: widget.maxLines,
+      onChanged: _handleChanged,
+      onSubmitted: widget.onSubmitted,
+    );
+  }
+}

--- a/packages/flutter_smart_debouncer_widgets/pubspec.yaml
+++ b/packages/flutter_smart_debouncer_widgets/pubspec.yaml
@@ -1,0 +1,22 @@
+name: flutter_smart_debouncer_widgets
+version: 0.1.0
+
+description: Flutter widgets built on top of flutter_smart_debouncer.
+repository: https://github.com/example/flutter_smart_debouncer
+issue_tracker: https://github.com/example/flutter_smart_debouncer/issues
+homepage: https://github.com/example/flutter_smart_debouncer
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.10.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_smart_debouncer:
+    path: ../flutter_smart_debouncer
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0

--- a/packages/flutter_smart_debouncer_widgets/test/debounced_text_field_test.dart
+++ b/packages/flutter_smart_debouncer_widgets/test/debounced_text_field_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_smart_debouncer_widgets/debounced_text_field.dart';
+
+void main() {
+  testWidgets('emits debounced value after delay', (tester) async {
+    var debouncedValue = '';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DebouncedTextField(
+            delay: const Duration(milliseconds: 200),
+            onChangedDebounced: (value) => debouncedValue = value,
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(debouncedValue, isEmpty);
+
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(debouncedValue, 'hello');
+  });
+
+  testWidgets('leading true emits immediately', (tester) async {
+    var debouncedValue = '';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DebouncedTextField(
+            delay: const Duration(milliseconds: 200),
+            leading: true,
+            onChangedDebounced: (value) => debouncedValue = value,
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'hi');
+    await tester.pump();
+    expect(debouncedValue, 'hi');
+  });
+}


### PR DESCRIPTION
## Summary
- add the flutter_smart_debouncer Dart package with SmartDebouncer, SmartThrottle, DebouncePool, stream helpers, and DebouncedValue
- add documentation, examples, analysis options, unit tests, and CI workflow for the core package
- provide optional flutter_smart_debouncer_widgets package with DebouncedTextField, example app, and widget tests

## Testing
- unable to run tests locally (dart and flutter binaries not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf251eeca08328b18ccb2b41ea257e